### PR TITLE
Fix: Controller 에서 사용할 인증유저용 ArgumentResolver 추가

### DIFF
--- a/src/main/java/com/goorm/okim/config/SecurityConfig.java
+++ b/src/main/java/com/goorm/okim/config/SecurityConfig.java
@@ -25,6 +25,7 @@ public class SecurityConfig {
                     .authorizeHttpRequests()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/user/**").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/user/**").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/task/**").authenticated()
                         .anyRequest().permitAll()
                 .and()
                     .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/goorm/okim/config/WebConfig.java
+++ b/src/main/java/com/goorm/okim/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.goorm.okim.config;
+
+import com.goorm.okim.jwt.CurrentUserIdResolver;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private CurrentUserIdResolver currentUserIdResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserIdResolver);
+    }
+}

--- a/src/main/java/com/goorm/okim/jwt/CurrentUserIdResolver.java
+++ b/src/main/java/com/goorm/okim/jwt/CurrentUserIdResolver.java
@@ -1,0 +1,31 @@
+package com.goorm.okim.jwt;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CurrentUserIdResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(Login.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) throws Exception {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getDetails();
+
+        return userDetails.getId();
+    }
+}

--- a/src/main/java/com/goorm/okim/jwt/CustomUserDetails.java
+++ b/src/main/java/com/goorm/okim/jwt/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.goorm.okim.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Getter @ToString
+@Component
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private long id;
+    private String sub;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.sub;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/goorm/okim/jwt/CustomUserPrincipal.java
+++ b/src/main/java/com/goorm/okim/jwt/CustomUserPrincipal.java
@@ -1,9 +1,0 @@
-package com.goorm.okim.jwt;
-
-import lombok.AllArgsConstructor;
-
-@AllArgsConstructor
-public class CustomUserPrincipal {
-    private long id;
-    private String sub;
-}

--- a/src/main/java/com/goorm/okim/jwt/JwtProvider.java
+++ b/src/main/java/com/goorm/okim/jwt/JwtProvider.java
@@ -8,9 +8,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.security.Principal;
 
 
 @Slf4j
@@ -54,8 +58,10 @@ public class JwtProvider implements InitializingBean {
         long id = Long.parseLong(String.valueOf(claims.get("uid")));
         String sub = (String) claims.get("sub");
 
-        CustomUserPrincipal principal = new CustomUserPrincipal(id, sub);
-        return new UsernamePasswordAuthenticationToken(principal, null, null);
+        CustomUserDetails userDetails = new CustomUserDetails(id, sub);
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        authToken.setDetails(userDetails);
+        return authToken;
     }
 
     private Claims extractAllClaims(String token) {

--- a/src/main/java/com/goorm/okim/jwt/Login.java
+++ b/src/main/java/com/goorm/okim/jwt/Login.java
@@ -1,0 +1,11 @@
+package com.goorm.okim.jwt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}


### PR DESCRIPTION
1. CurrentUserIdResolver 추가
- 인증된 사용자 id 를 쉽게 가져오기 위해서 만듬
- @Login annotation 을 필요로 하는 Controller 메서드에 argument로 넣어 사용하면 됨
```java

public ResponseEntity<?> test(@Login long userId){

}

```

Related to #26